### PR TITLE
DFU-Library bump for CBPeripheral API change

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.0.1
+current_version = 4.0.2
 
 [bumpversion:file:Docs/source/conf.py]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [4.0.2] - 2021-08-05
+### Update
+- Update iOSDUFLibrary pod for Swift 5.5 CBPeripheral API change 
+
 ## [4.0.1] - 2021-06-15
 ### Update
 - General update and cleanup (no major changes)

--- a/MetaWear.podspec
+++ b/MetaWear.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name               = 'MetaWear'
-  s.version            = '4.0.1'
+  s.version            = '4.0.2'
   s.license            = { :type => 'Commercial', :text => 'See https://www.mbientlab.com/terms/', :file => 'LICENSE.md' }
   s.homepage           = 'https://mbientlab.com'
   s.summary            = 'iOS/macOS/tvOS/watchOS API and documentation for the MetaWear platform'
@@ -73,6 +73,6 @@ Pod::Spec.new do |s|
 
       s.source_files = 'MetaWear/DFU/**/*'
       s.dependency 'MetaWear/Core'
-      s.dependency 'iOSDFULibrary', '4.10.3'
+      s.dependency 'iOSDFULibrary', '4.11.0'
   end
 end

--- a/MetaWear/Core/MetaWear.swift
+++ b/MetaWear/Core/MetaWear.swift
@@ -318,13 +318,13 @@ public class MetaWear: NSObject {
         invokeConnectionHandlers(error: error, cancelled: false)
         invokeDisconnectionHandlers(error: error)
         
-        logDelegate?.logWith(.info, message: "didFailToConnect: \(error)")
+        logDelegate?.logWith(.info, message: "didFailToConnect: \(String(describing: error))")
     }
     func didDisconnectPeripheral(error: Error?) {
         invokeConnectionHandlers(error: error, cancelled: error == nil)
         invokeDisconnectionHandlers(error: error)
         
-        logDelegate?.logWith(.info, message: "didDisconnectPeripheral: \(error)")
+        logDelegate?.logWith(.info, message: "didDisconnectPeripheral: \(String(describing: error))")
     }
     func invokeDisconnectionHandlers(error: Error?) {
         assert(DispatchQueue.isBleQueue)

--- a/MetaWear/Podfile.lock
+++ b/MetaWear/Podfile.lock
@@ -1,17 +1,17 @@
 PODS:
   - Bolts-Swift (1.5.0)
-  - iOSDFULibrary (4.10.3):
+  - iOSDFULibrary (4.11.0):
     - ZIPFoundation (= 0.9.11)
-  - MetaWear/AsyncUtils (4.0.1):
+  - MetaWear/AsyncUtils (4.0.2):
     - MetaWear/Core
-  - MetaWear/Core (4.0.1):
+  - MetaWear/Core (4.0.2):
     - Bolts-Swift (~> 1)
-  - MetaWear/DFU (4.0.1):
-    - iOSDFULibrary (= 4.10.3)
+  - MetaWear/DFU (4.0.2):
+    - iOSDFULibrary (= 4.11.0)
     - MetaWear/Core
-  - MetaWear/Mocks (4.0.1):
+  - MetaWear/Mocks (4.0.2):
     - MetaWear/Core
-  - MetaWear/UI (4.0.1):
+  - MetaWear/UI (4.0.2):
     - MetaWear/AsyncUtils
     - MetaWear/Core
   - ZIPFoundation (0.9.11)
@@ -34,8 +34,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Bolts-Swift: afbbaf8c8186e7f769be4afa656949c14087ba44
-  iOSDFULibrary: 7aade51a907d01ca9a87055003cd232b09efd78f
-  MetaWear: 35f29152e275456bdbfcd75eae8830f51cfec729
+  iOSDFULibrary: ca2a4da1f1680fe4957b0a33ad605c9e10f7ae7c
+  MetaWear: f3f04a5efa810a6a61862912b22958ae304dbd54
   ZIPFoundation: b1f0de4eed33e74a676f76e12559ab6b75990197
 
 PODFILE CHECKSUM: 6d9441a1971d75fea48dd089467f2b90a99a8503

--- a/MetaWear/UI/ScannerModel.swift
+++ b/MetaWear/UI/ScannerModel.swift
@@ -37,7 +37,7 @@ import CoreBluetooth
 import MetaWearCpp
 
 /// Callbacks from ScannerModel
-public protocol ScannerModelDelegate: class {
+public protocol ScannerModelDelegate: AnyObject {
     func scannerModel(_ scannerModel: ScannerModel, didAddItemAt idx: Int)
     func scannerModel(_ scannerModel: ScannerModel, confirmBlinkingItem item: ScannerModelItem, callback: @escaping (Bool) -> Void)
     func scannerModel(_ scannerModel: ScannerModel, errorDidOccur error: Error)


### PR DESCRIPTION
Apple recently changed CBPeripheral to be an [optional](https://developer.apple.com/documentation/corebluetooth/cbservice/1434334-peripheral?changes=latest_minor). A new [patch](https://github.com/NordicSemiconductor/IOS-DFU-Library/pull/433) of the DFU Library handles that. 

Unfortunately, the signal strength of the MetaWear I have is too poor to run the integration tests. So I can't know how this change may affect your code beyond using the patch while building the macOS app.