### PR TITLE
Address warning in Xcode 13 for macOS test host

### DIFF
--- a/MetaWear/Tests/MetaWearIntegrationTestHost-macOS/Info.plist
+++ b/MetaWear/Tests/MetaWearIntegrationTestHost-macOS/Info.plist
@@ -28,5 +28,9 @@
 	<string>Main</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSBluetoothPeripheralUsageDescription</key>
+	<string>Testing</string>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Testing</string>
 </dict>
 </plist>

--- a/MetaWear/Tests/MetaWearIntegrationTestHost-tvOS/Info.plist
+++ b/MetaWear/Tests/MetaWearIntegrationTestHost-tvOS/Info.plist
@@ -28,5 +28,9 @@
 	</array>
 	<key>UIUserInterfaceStyle</key>
 	<string>Automatic</string>
+	<key>NSBluetoothPeripheralUsageDescription</key>
+	<string>Testing</string>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Testing</string>
 </dict>
 </plist>

--- a/MetaWear/Tests/MetaWearIntegrationTestHost-watchOS/Info.plist
+++ b/MetaWear/Tests/MetaWearIntegrationTestHost-watchOS/Info.plist
@@ -29,5 +29,9 @@
 	<string>com.mbientlab.MetaWearIntegrationTestHost-iOS</string>
 	<key>WKWatchKitApp</key>
 	<true/>
+	<key>NSBluetoothPeripheralUsageDescription</key>
+	<string>Testing</string>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Testing</string>
 </dict>
 </plist>


### PR DESCRIPTION
Adds BLE permissions to test hosts without (that otherwise crash on Xcode 13).