### PR TITLE
Fix compiler error by adding 'try!'

### DIFF
--- a/MetaWear/DFU/FirmwareBuild.swift
+++ b/MetaWear/DFU/FirmwareBuild.swift
@@ -86,9 +86,9 @@ public struct FirmwareBuild {
         return task.continueOnSuccessWithTask { fileUrl in
             var selectedFirmware: DFUFirmware?
             if fileUrl.pathExtension.caseInsensitiveCompare("zip") == .orderedSame {
-                selectedFirmware = DFUFirmware(urlToZipFile: fileUrl)
+                selectedFirmware = try! DFUFirmware(urlToZipFile: fileUrl)
             } else {
-                selectedFirmware = DFUFirmware(urlToBinOrHexFile: fileUrl, urlToDatFile: nil, type: .application)
+                selectedFirmware = try! DFUFirmware(urlToBinOrHexFile: fileUrl, urlToDatFile: nil, type: .application)
             }
             guard let firmware = selectedFirmware else {
                 return Task<DFUFirmware>(error: MetaWearError.operationFailed(message: "invalid dfu file chosen '\(fileUrl.lastPathComponent)'"))


### PR DESCRIPTION
Master branch does not compile due to build error: 

> Swift Compiler Error (Xcode): Call can throw, but it is not marked with 'try' and the error is not handled
> /Users/stevebroshar/code/tremor_poc_app/ios/Pods/MetaWear/MetaWear/DFU/FirmwareBuild.swift:88:35
> Swift Compiler Error (Xcode): Call can throw, but it is not marked with 'try' and the error is not handled
> /Users/stevebroshar/code/tremor_poc_app/ios/Pods/MetaWear/MetaWear/DFU/FirmwareBuild.swift:90:35

This change adds 'try!' to eliminate this error. Honestly, I don't know whether this is a good way to fix. But, it's surely better to compile than to not.
